### PR TITLE
Add confirmation window before removing admin

### DIFF
--- a/app/client/views/admin/users/adminUsersCtrl.js
+++ b/app/client/views/admin/users/adminUsersCtrl.js
@@ -213,12 +213,38 @@ angular.module('reg')
             }
           );
         } else {
-          UserService
+          swal({
+            title: "Whoa, wait a minute!",
+            text: "You are about to remove " + user.profile.name + " as an admin!",
+            icon: "warning",
+            buttons: {
+              cancel: {
+                text: "Cancel",
+                value: null,
+                visible: true
+              },
+              confirm: {
+                text: "Yes, remove them",
+                className: "danger-button",
+                closeModal: false,
+                value: true,
+                visible: true
+              }
+            }
+          }).then(value => {
+            if (!value) {
+              return;
+            }
+
+            UserService
             .removeAdmin(user._id)
             .then(response => {
               $scope.users[index] = response.data;
-              swal("Removed", response.data.profile.name + ' as admin', "success");
+              swal("Removed", 'Removed ' + response.data.profile.name + ' as an admin', "success");
             });
+            }
+          );
+          
         }
       };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
The application now confirms with the user if he wants to really remove the admin, preventing mistakes.

## Motivation and Context
Preventing from the admin from accidentally removing itself (ahem ahem)

## Screenshots (if appropriate)
![Screen Shot 2021-08-04 at 21 03 44](https://user-images.githubusercontent.com/53123142/128231707-f45dc22e-f81b-424f-9f70-13835e4f13c9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
